### PR TITLE
Updated all mass fitting routines for generic file locations

### DIFF
--- a/analysis/Scripts/Imports.py
+++ b/analysis/Scripts/Imports.py
@@ -51,7 +51,22 @@ def plot_comparison(varname, xmin, xmax, tree1, tree2, bins=100, cuts1 = "1==1",
     return
 
 subjobs = 101
-filedir = "/Users/simoncalo/LHCb_data/datafiles/first_batch/ganga/4_reduced"
+#File dir for data, uncomment the version for each person
+#Calo
+#pwd="/Users/simoncalo/LHCb_data/datafiles/first_batch/ganga/"
+#Pawley
+pwd="/home/chris/Documents/LHCB/Data/"
+
+#File dir for MC, uncomment the version(s) for each person
+#Calo
+#mcpwd="/Users/simoncalo/LHCb_data/datafiles/Lc_MC_datafiles_2/ganga/"
+#ximcpwd="/Users/simoncalo/LHCb_data/datafiles/XIc_MC_datafiles_1/ganga/"
+#ximc2pwd="/Users/simoncalo/LHCb_data/datafiles/XIc_MC_datafiles_2/ganga/"
+#mcbmcpwd="/Users/simoncalo/LHCb_data/datafiles/MC_B->Lc_datafiles/ganga/"
+#Pawley
+mcpwd=ximcpwd=ximc2pwd=mcbmcpwd=pwd
+
+filedir = pwd+"4_reduced"
 filename = "charm_29r2_g.root"
 excludedjobs = []
 
@@ -64,7 +79,7 @@ def datatree():
         tree.Add(filedir + "/" + str(job) + "/output/" + filename)
     return tree
 
-Lc_MC_filedir = "/Users/simoncalo/LHCb_data/datafiles/Lc_MC_datafiles_2/ganga/15"
+Lc_MC_filedir = mcpwd+"15"
 Lc_MC_filename = "MC_Lc2pKpiTuple_25103006.root"
 
 Lc_MC_tree = TChain("tuple_Lc2pKpi/DecayTree")
@@ -75,7 +90,7 @@ def Lc_MC_datatree():
             Lc_MC_tree.Add("{0}/{1}/output/{2}".format(Lc_MC_filedir,job,Lc_MC_filename))
     return Lc_MC_tree
 
-Xic_MC_filedir_1 = "/Users/simoncalo/LHCb_data/datafiles/XIc_MC_datafiles_1/ganga/17"
+Xic_MC_filedir_1 = ximcpwd+"17"
 Xic_MC_filename_1 = "MC_Lc2pKpiTuple_25103029.root"
 
 Xic_MC_tree_1 = TChain("tuple_Lc2pKpi/DecayTree")
@@ -86,7 +101,7 @@ def Xic_MC_datatree_1 ():
             #print ("- Adding subjob {0}".format(job))
             Xic_MC_tree_1.Add("{0}/{1}/output/{2}".format(Xic_MC_filedir_1,job,Xic_MC_filename_1))
 
-Xic_MC_filedir_2 = "/Users/simoncalo/LHCb_data/datafiles/XIc_MC_datafiles_2/ganga/18"
+Xic_MC_filedir_2 = ximc2pwd+"18"
 Xic_MC_filename_2 = "MC_Lc2pKpiTuple_25103036.root"
 
 Xic_MC_tree_2 = TChain("tuple_Lc2pKpi/DecayTree")
@@ -97,7 +112,7 @@ def Xic_MC_datatree_2():
             #print ("- Adding subjob {0}".format(job))
             Xic_MC_tree_2.Add("{0}/{1}/output/{2}".format(Xic_MC_filedir_2,job,Xic_MC_filename_2))
 
-Lb_MC_filedir = "/Users/simoncalo/LHCb_data/datafiles/MC_B->Lc_datafiles/ganga/14"
+Lb_MC_filedir =mcbmcpwd+ "14"
 Lb_MC_filename = "MC_Lc2pKpiTuple_15264011.root"
 
 Lb_MC_tree = TChain("tuple_Lc2pKpi/DecayTree")

--- a/analysis/Scripts/Lc_Mass_Fit.py
+++ b/analysis/Scripts/Lc_Mass_Fit.py
@@ -1,8 +1,9 @@
 import ROOT, os
 from ROOT import TChain, TCanvas, TH1
+from Imports import *
 
 subjobs = 101
-filedir = "datafiles/first_batch/ganga/4_reduced"
+filedir =pwd+"4_reduced"
 filename = "charm_29r2_g.root"
 excludedjobs = []
 
@@ -108,7 +109,7 @@ leg.AddEntry( histogram1, "Signal shape", "l")
 leg.AddEntry(histogram2, "Background", "l")
 leg.Draw("same")
 graph_name = ("Lc_Mass_Fit.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 c1.SaveAs(fullpath)
 
@@ -158,7 +159,7 @@ cpull.Draw()
 
 
 graph_name = ("Lc_Mass_Fit_pull.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 cpull.SaveAs(fullpath)
 

--- a/analysis/Scripts/MC_Lc_Mass_Fit.py
+++ b/analysis/Scripts/MC_Lc_Mass_Fit.py
@@ -1,7 +1,8 @@
 import ROOT,os
 from ROOT import TChain, TCanvas, TH1
+from Imports import *
 
-Lc_MC_filedir = "datafiles/Lc_MC_datafiles_2/ganga/15"
+Lc_MC_filedir =mcpwd+"15"
 Lc_MC_filename = "MC_Lc2pKpiTuple_25103006.root"
 
 Lc_MC_tree = TChain("tuple_Lc2pKpi/DecayTree")
@@ -93,7 +94,7 @@ leg.AddEntry( histogram1, "Gaussian", "l")
 leg.AddEntry(histogram2, "Crystal ball", "l")
 leg.Draw("same")
 graph_name = ("MC_Lc_Mass_Fit.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 c1.SaveAs(fullpath)
 
@@ -144,7 +145,7 @@ cpull.Draw()
 
 
 graph_name = ("MC_Lc_Mass_Fit_pull.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 cpull.SaveAs(fullpath)
 

--- a/analysis/Scripts/Mass_histogram.py
+++ b/analysis/Scripts/Mass_histogram.py
@@ -1,9 +1,9 @@
 import ROOT, os, Imports
 from ROOT import TChain, TCanvas, TH1
-
+from Imports import *
 
 subjobs = 101
-filedir = "/Users/simoncalo/LHCb_data/datafiles/first_batch/ganga/4_reduced"
+filedir = pwd+"4_reduced"
 filename = "charm_29r2_g.root"
 excludedjobs = []
 
@@ -41,7 +41,7 @@ if choice == "yes":
     c1.Update()
     c1.Draw()
     graph_name = ("mass_cut_test.pdf")
-    filepath = ("/Users/simoncalo/LHCb_data")
+    filepath = (pwd)
     fullpath = os.path.join(filepath, graph_name)
     c1.SaveAs(fullpath)
 else:
@@ -53,7 +53,7 @@ else:
     c1.Update()
     c1.Draw()
     graph_name = ("mass.pdf")
-    filepath = ("/Users/simoncalo/LHCb_data")
+    filepath = (pwd)
     fullpath = os.path.join(filepath, graph_name)
     c1.SaveAs(fullpath)
 

--- a/analysis/Scripts/Xic_MC_1_Mass_Fit.py
+++ b/analysis/Scripts/Xic_MC_1_Mass_Fit.py
@@ -1,7 +1,8 @@
 import ROOT, os
 from ROOT import TChain, TCanvas, TH1
+from Imports import *
 
-Xic_MC_filedir = "/Users/simoncalo/LHCb_data/datafiles/XIc_MC_datafiles_1/ganga/17"
+Xic_MC_filedir = ximcpwd+"17"
 Xic_MC_filename = "MC_Lc2pKpiTuple_25103029.root"
 
 Xic_MC_tree = TChain("tuple_Lc2pKpi/DecayTree")
@@ -98,7 +99,7 @@ leg.AddEntry( histogram1, "Gaussian", "l")
 leg.AddEntry(histogram2, "Crystal ball", "l")
 leg.Draw("same")
 graph_name = ("Xic_MC_1_Mass_Fit.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 c1.SaveAs(fullpath)
 
@@ -149,7 +150,7 @@ cpull.Draw()
 
 
 graph_name = ("Xic_MC_1_Mass_Fit_pull.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 cpull.SaveAs(fullpath)
 

--- a/analysis/Scripts/Xic_MC_2_Mass_Fit.py
+++ b/analysis/Scripts/Xic_MC_2_Mass_Fit.py
@@ -1,7 +1,8 @@
 import ROOT, os
 from ROOT import TChain, TCanvas, TH1
+from Imports import *
 
-Xic_MC_filedir = "/Users/simoncalo/LHCb_data/datafiles/XIc_MC_datafiles_2/ganga/18"
+Xic_MC_filedir = ximc2pwd+"18"
 Xic_MC_filename = "MC_Lc2pKpiTuple_25103036.root"
 
 Xic_MC_tree = TChain("tuple_Lc2pKpi/DecayTree")
@@ -98,7 +99,7 @@ leg.AddEntry( histogram1, "Gaussian", "l")
 leg.AddEntry(histogram2, "Crystal ball", "l")
 leg.Draw("same")
 graph_name = ("Xic_MC_2_Mass_Fit.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 c1.SaveAs(fullpath)
 
@@ -148,7 +149,7 @@ cpull.Draw()
 
 
 graph_name = ("Xic_MC_2_Mass_Fit_pull.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 cpull.SaveAs(fullpath)
 

--- a/analysis/Scripts/Xic_Mass_Fit.py
+++ b/analysis/Scripts/Xic_Mass_Fit.py
@@ -1,8 +1,9 @@
 import ROOT, os
 from ROOT import TChain, TCanvas, TH1
+from Imports import *
 
 subjobs = 101
-filedir = "datafiles/first_batch/ganga/4_reduced"
+filedir = pwd+"/4_reduced"
 filename = "charm_29r2_g.root"
 excludedjobs = []
 
@@ -109,7 +110,7 @@ leg.AddEntry( histogram1, "Signal Shape", "l")
 leg.AddEntry(histogram2, "Background", "l")
 leg.Draw("same")
 graph_name = ("Xic_Mass_Fit.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 c1.SaveAs(fullpath)
 
@@ -159,7 +160,7 @@ cpull.Draw()
 
 
 graph_name = ("Xic_Mass_Fit_pull.pdf")
-filepath = ("/Users/simoncalo/LHCb_data")
+filepath = pwd
 fullpath = os.path.join(filepath, graph_name)
 cpull.SaveAs(fullpath)
 


### PR DESCRIPTION
References to specific file locations only need to be determined in "Imports.py" - this then leads all other scripts to look in the right location for the files we require.

@SimonCalo - this will output your PDFs for all mass fits to "/Users/simoncalo/LHCb_data/datafiles/first_batch/ganga/"

Maybe you would prefer to have that somewhere else, might need some modification to suit individual preferences...